### PR TITLE
fix: api returning 404

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,7 @@ export const ServerList = [
   /**
    * The production server.
    */
-  "https://api.re-tell.ai",
+  "https://api.retellai.com",
 ] as const;
 
 export type SDKOptions = {


### PR DESCRIPTION
`https://api.re-tell.ai` is currently returning 404 on all requests made through the SDK.